### PR TITLE
Remove duplicate link to Stephen Toub blog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,8 +96,6 @@ Contributions are always welcome! Thanks to all contributors, you're awesome and
 
 [An Introduction to System.Threading.Channels - Stephen Toub](https://devblogs.microsoft.com/dotnet/an-introduction-to-system-threading-channels/)
 
-[An Introduction to System.Threading.Channels](https://devblogs.microsoft.com/dotnet/an-introduction-to-system-threading-channels/)
-
 [Using Channels In C# .NET Core – Part 1 – Getting Started](https://dotnetcoretutorials.com/2020/11/24/using-channels-in-net-core-part-1-getting-started/)
 
 [Using Channels In C# .NET Core – Part 2 – Advanced Channels](https://dotnetcoretutorials.com/2020/11/24/using-channels-in-net-core-part-2-advanced-channels/)


### PR DESCRIPTION
Remove duplicate link to Stephen Toub blog